### PR TITLE
Use system line seperator for platform independence

### DIFF
--- a/src/main/java/renderer/Shader.java
+++ b/src/main/java/renderer/Shader.java
@@ -30,12 +30,12 @@ public class Shader {
 
             // Find the first pattern after #type 'pattern'
             int index = source.indexOf("#type") + 6;
-            int eol = source.indexOf("\r\n", index);
+            int eol = source.indexOf(System.lineSeparator(), index);
             String firstPattern = source.substring(index, eol).trim();
 
             // Find the second pattern after #type 'pattern'
             index = source.indexOf("#type", eol) + 6;
-            eol = source.indexOf("\r\n", index);
+            eol = source.indexOf(System.lineSeparator(), index);
             String secondPattern = source.substring(index, eol).trim();
 
             if (firstPattern.equals("vertex")) {


### PR DESCRIPTION
Mac uses "\n" and so does Unix while Windows uses "\r\n" for end of line. To make it work for all platforms `System.lineSeparator()` can be used which was introduced in Java 7.